### PR TITLE
Add per-user API keys with global fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Sonobarr marries your existing Lidarr library with Last.fm's discovery graph to 
 - ⚡️ **Real-time UX** - Socket.IO keeps discovery progress, toast alerts, and button states in sync across every connected client.
 - 👥 **Role-based access** - authentication, user management, profile controls for personal services, and admin-only settings live in one UI.
 - 🔐 **OIDC Single Sign-On** - enable OpenID Connect for authentication, with optional group-based admin assignment and "OIDC-only" mode.
+- 🔑 **Per-user API keys** - users can optionally bring their own Last.fm, YouTube, and LLM keys, with automatic fallback to admin-configured global keys.
 - 🛡️ **Hardened configuration** - atomic settings writes, locked-down file permissions, and CSRF-protected forms keep secrets safe.
 - 🔔 **Update & schema self-healing** - footer badges surface new releases and the app backfills missing DB columns before loading users.
 - 🐳 **Docker-first deployment** - official GHCR image, rootless-friendly UID/GID mapping, and automatic migrations on start.
@@ -183,7 +184,6 @@ When configuring your OIDC provider, you **must** register a Redirect URI (or Ca
 `https://[YOUR_SONOBARR_DOMAIN_OR_IP]/oidc/callback`
 
 For security, OIDC providers require `https` for all production URLs. For local development, most providers allow `http://localhost:[port]` as an exception.
-
 ---
 
 ## Using the app

--- a/migrations/versions/20251223_01_add_user_api_keys.py
+++ b/migrations/versions/20251223_01_add_user_api_keys.py
@@ -1,0 +1,61 @@
+"""add per-user api keys
+
+Revision ID: 20251223_01
+Revises: 20251013_01
+Create Date: 2025-12-23 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision = '20251223_01'
+down_revision = '20260303_01'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    existing_columns = {column["name"] for column in inspector.get_columns("users")}
+
+    columns_to_add = [
+        ("lastfm_api_key", sa.String(length=256)),
+        ("lastfm_api_secret", sa.String(length=256)),
+        ("youtube_api_key", sa.String(length=256)),
+        ("openai_api_key", sa.String(length=512)),
+        ("openai_api_base", sa.String(length=512)),
+        ("openai_model", sa.String(length=128)),
+        ("openai_extra_headers", sa.Text()),
+        ("openai_max_seed_artists", sa.Integer()),
+    ]
+
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        for column_name, column_type in columns_to_add:
+            if column_name not in existing_columns:
+                batch_op.add_column(sa.Column(column_name, column_type, nullable=True))
+
+
+def downgrade():
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    existing_columns = {column["name"] for column in inspector.get_columns("users")}
+
+    columns_to_remove = [
+        "lastfm_api_key",
+        "lastfm_api_secret",
+        "youtube_api_key",
+        "openai_api_key",
+        "openai_api_base",
+        "openai_model",
+        "openai_extra_headers",
+        "openai_max_seed_artists",
+    ]
+
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        for column_name in columns_to_remove:
+            if column_name in existing_columns:
+                batch_op.drop_column(column_name)

--- a/src/sonobarr_app/models.py
+++ b/src/sonobarr_app/models.py
@@ -21,6 +21,17 @@ class User(UserMixin, db.Model):
     avatar_url = db.Column(db.String(512), nullable=True)
     lastfm_username = db.Column(db.String(120), nullable=True)
     listenbrainz_username = db.Column(db.String(120), nullable=True)
+
+    # Per-user API keys (optional - fall back to global if not set)
+    lastfm_api_key = db.Column(db.String(256), nullable=True)
+    lastfm_api_secret = db.Column(db.String(256), nullable=True)
+    youtube_api_key = db.Column(db.String(256), nullable=True)
+    openai_api_key = db.Column(db.String(512), nullable=True)
+    openai_api_base = db.Column(db.String(512), nullable=True)
+    openai_model = db.Column(db.String(128), nullable=True)
+    openai_extra_headers = db.Column(db.Text, nullable=True)
+    openai_max_seed_artists = db.Column(db.Integer, nullable=True)
+
     is_admin = db.Column(db.Boolean, default=False, nullable=False)
     is_active = db.Column(db.Boolean, default=True, nullable=False)
     auto_approve_artist_requests = db.Column(db.Boolean, default=False, nullable=False)

--- a/src/sonobarr_app/services/data_handler.py
+++ b/src/sonobarr_app/services/data_handler.py
@@ -408,20 +408,21 @@ class DataHandler:
         Uses user's API keys if set, otherwise falls back to global config.
         Returns None if no API key is available.
         """
+        user_has_custom_keys = user and (
+            getattr(user, 'openai_api_key', None) or
+            getattr(user, 'openai_api_base', None)
+        )
+
+        # If user has no custom keys, fall back to the global recommender directly
+        if not user_has_custom_keys and self.openai_recommender:
+            return self.openai_recommender
+
         api_key = (self.get_openai_api_key(user) or "").strip()
         base_url = (self.get_openai_api_base(user) or "").strip()
         env_api_key = os.environ.get("OPENAI_API_KEY", "").strip()
 
         if not any([api_key, base_url, env_api_key]):
             return None
-
-        # If user has no custom keys, use the global recommender
-        user_has_custom_keys = user and (
-            getattr(user, 'openai_api_key', None) or
-            getattr(user, 'openai_api_base', None)
-        )
-        if not user_has_custom_keys and self.openai_recommender:
-            return self.openai_recommender
 
         # Create a recommender with user's (or global) settings
         model = (self.get_openai_model(user) or "").strip() or None
@@ -854,23 +855,21 @@ class DataHandler:
         names = playlist_artists.artists if playlist_artists else []
         return [name for name in names if name]
 
-    def _personal_source_definitions(self, user=None) -> Dict[str, Dict[str, Any]]:
+    def _personal_source_definitions(self) -> Dict[str, Dict[str, Any]]:
         """Return source-specific metadata and loaders for personal recommendations."""
-        user_has_lastfm = bool(user and getattr(user, 'lastfm_api_key', None) and getattr(user, 'lastfm_api_secret', None))
-        lastfm_service_ready = bool(self.last_fm_user_service) or user_has_lastfm
         return {
             "lastfm": {
                 "label": "Last.fm",
                 "title": "Last.fm discovery",
                 "username_attr": "lastfm_username",
-                "service_ready": lastfm_service_ready,
+                "service_ready": bool(self.last_fm_user_service),
                 "service_missing_reason": (
                     "Administrator must configure a Last.fm API key and secret in Settings before this feature can be used."
                 ),
                 "missing_username_reason": (
                     "Add your Last.fm username under Profile → Listening services to use this feature."
                 ),
-                "fetch": lambda username: self._fetch_lastfm_personal_artists(username, user),
+                "fetch": self._fetch_lastfm_personal_artists,
                 "error_message": "We couldn't reach Last.fm right now. Please try again shortly.",
             },
             "listenbrainz": {
@@ -967,9 +966,8 @@ class DataHandler:
     def personal_recommendations(self, sid: str, source: str) -> None:
         session = self.ensure_session(sid)
         source_key = (source or "").strip().lower() or "lastfm"
-        user = self._resolve_user(session.user_id)
 
-        config = self._personal_source_definitions(user=user).get(source_key)
+        config = self._personal_source_definitions().get(source_key)
         if not config:
             self._emit_personal_error(
                 sid,
@@ -979,6 +977,7 @@ class DataHandler:
             )
             return
 
+        user = self._resolve_user(session.user_id)
         if not user:
             self._emit_personal_error(
                 sid,
@@ -987,6 +986,15 @@ class DataHandler:
                 title=config["title"],
             )
             return
+
+        # Allow BYO Last.fm keys to substitute for missing global service
+        if source_key == "lastfm" and not config["service_ready"]:
+            user_has_lastfm = bool(
+                getattr(user, 'lastfm_api_key', None) and getattr(user, 'lastfm_api_secret', None)
+            )
+            if user_has_lastfm:
+                config = dict(config, service_ready=True,
+                              fetch=lambda uname: self._fetch_lastfm_personal_artists(uname, user))
 
         if not config["service_ready"]:
             self._emit_personal_error(

--- a/src/sonobarr_app/services/data_handler.py
+++ b/src/sonobarr_app/services/data_handler.py
@@ -353,6 +353,110 @@ class DataHandler:
         self._sync_session_permissions(session)
         return bool(session.is_admin or session.auto_approve_artist_requests)
 
+    # Per-user API key getters with global fallback ----------------------
+    def get_lastfm_api_key(self, user: Optional[User] = None) -> str:
+        """Return user's Last.fm API key if set, else fall back to global."""
+        if user and getattr(user, 'lastfm_api_key', None):
+            return user.lastfm_api_key
+        return self.last_fm_api_key
+
+    def get_lastfm_api_secret(self, user: Optional[User] = None) -> str:
+        """Return user's Last.fm API secret if set, else fall back to global."""
+        if user and getattr(user, 'lastfm_api_secret', None):
+            return user.lastfm_api_secret
+        return self.last_fm_api_secret
+
+    def get_youtube_api_key(self, user: Optional[User] = None) -> str:
+        """Return user's YouTube API key if set, else fall back to global."""
+        if user and getattr(user, 'youtube_api_key', None):
+            return user.youtube_api_key
+        return self.youtube_api_key
+
+    def get_openai_api_key(self, user: Optional[User] = None) -> str:
+        """Return user's OpenAI API key if set, else fall back to global."""
+        if user and getattr(user, 'openai_api_key', None):
+            return user.openai_api_key
+        return self.openai_api_key
+
+    def get_openai_api_base(self, user: Optional[User] = None) -> str:
+        """Return user's OpenAI API base if set, else fall back to global."""
+        if user and getattr(user, 'openai_api_base', None):
+            return user.openai_api_base
+        return self.openai_api_base
+
+    def get_openai_model(self, user: Optional[User] = None) -> str:
+        """Return user's OpenAI model if set, else fall back to global."""
+        if user and getattr(user, 'openai_model', None):
+            return user.openai_model
+        return self.openai_model
+
+    def get_openai_extra_headers(self, user: Optional[User] = None) -> str:
+        """Return user's OpenAI extra headers if set, else fall back to global."""
+        if user and getattr(user, 'openai_extra_headers', None):
+            return user.openai_extra_headers
+        return self.openai_extra_headers
+
+    def get_openai_max_seed_artists(self, user: Optional[User] = None) -> int:
+        """Return user's OpenAI max seed artists if set, else fall back to global."""
+        if user and getattr(user, 'openai_max_seed_artists', None) is not None:
+            return user.openai_max_seed_artists
+        return self.openai_max_seed_artists
+
+    def get_openai_recommender_for_user(self, user: Optional[User] = None) -> Optional["OpenAIRecommender"]:
+        """
+        Get an OpenAI recommender configured for the user.
+        Uses user's API keys if set, otherwise falls back to global config.
+        Returns None if no API key is available.
+        """
+        api_key = (self.get_openai_api_key(user) or "").strip()
+        base_url = (self.get_openai_api_base(user) or "").strip()
+        env_api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+
+        if not any([api_key, base_url, env_api_key]):
+            return None
+
+        # If user has no custom keys, use the global recommender
+        user_has_custom_keys = user and (
+            getattr(user, 'openai_api_key', None) or
+            getattr(user, 'openai_api_base', None)
+        )
+        if not user_has_custom_keys and self.openai_recommender:
+            return self.openai_recommender
+
+        # Create a recommender with user's (or global) settings
+        model = (self.get_openai_model(user) or "").strip() or None
+        max_seeds = self.get_openai_max_seed_artists(user)
+        try:
+            max_seeds_int = int(max_seeds)
+        except (TypeError, ValueError):
+            max_seeds_int = DEFAULT_MAX_SEED_ARTISTS
+        if max_seeds_int <= 0:
+            max_seeds_int = DEFAULT_MAX_SEED_ARTISTS
+
+        # Parse extra headers
+        headers_raw = self.get_openai_extra_headers(user)
+        headers_override = {}
+        if headers_raw:
+            try:
+                import json
+                parsed = json.loads(headers_raw)
+                if isinstance(parsed, dict):
+                    headers_override = {str(k).strip(): str(v) for k, v in parsed.items() if k and v is not None}
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        try:
+            return OpenAIRecommender(
+                api_key=api_key or None,
+                model=model,
+                base_url=base_url or None,
+                default_headers=headers_override or None,
+                max_seed_artists=max_seeds_int,
+            )
+        except Exception as exc:
+            self.logger.error("Failed to initialize user LLM client: %s", exc)
+            return None
+
     def emit_personal_sources_state(self, sid: str) -> None:
         session = self.get_session_if_exists(sid)
         if session is None:
@@ -360,7 +464,8 @@ class DataHandler:
 
         user = self._resolve_user(session.user_id)
 
-        lastfm_service_ready = self.last_fm_user_service is not None
+        user_has_lastfm_keys = bool(user and getattr(user, 'lastfm_api_key', None) and getattr(user, 'lastfm_api_secret', None))
+        lastfm_service_ready = self.last_fm_user_service is not None or user_has_lastfm_keys
         lastfm_username = user.lastfm_username if user else None
         lastfm_enabled = bool(lastfm_service_ready and lastfm_username)
         if not lastfm_service_ready:
@@ -632,6 +737,7 @@ class DataHandler:
 
     def ai_prompt(self, sid: str, prompt: str) -> None:
         session = self.ensure_session(sid)
+        user = self._resolve_user(session.user_id)
         prompt_text = (prompt or "").strip()
         if not prompt_text:
             self._emit_ai_prompt_error(
@@ -640,10 +746,12 @@ class DataHandler:
             )
             return
 
-        if not self.openai_recommender:
+        # Get recommender with user's API keys (or fallback to global)
+        recommender = self.get_openai_recommender_for_user(user)
+        if not recommender:
             self._emit_ai_prompt_error(
                 sid,
-                "AI assistant isn't configured yet. Add an LLM API key or base URL in settings.",
+                "AI assistant isn't configured yet. Add an LLM API key in settings or your profile.",
             )
             return
 
@@ -652,8 +760,8 @@ class DataHandler:
             cleaned_library_names = set(self.cached_cleaned_lidarr_names)
 
         prompt_preview = prompt_text if len(prompt_text) <= 120 else f"{prompt_text[:117]}..."
-        model_name = getattr(self.openai_recommender, "model", "unknown")
-        timeout_value = getattr(self.openai_recommender, "timeout", None)
+        model_name = getattr(recommender, "model", "unknown")
+        timeout_value = getattr(recommender, "timeout", None)
         self.logger.info(
             "AI prompt started (model=%s, timeout=%s, library_size=%d, prompt=\"%s\")",
             model_name,
@@ -664,7 +772,7 @@ class DataHandler:
 
         start_time = time.perf_counter()
         try:
-            seeds = self.openai_recommender.generate_seed_artists(prompt_text, library_artists)
+            seeds = recommender.generate_seed_artists(prompt_text, library_artists)
         except Exception as exc:  # pragma: no cover - network errors
             elapsed = time.perf_counter() - start_time
             self.logger.error("AI prompt failed after %.2fs: %s", elapsed, exc)
@@ -728,12 +836,15 @@ class DataHandler:
         if not success:
             return
 
-    def _fetch_lastfm_personal_artists(self, username: str) -> List[str]:
-        if not self.last_fm_user_service:
+    def _fetch_lastfm_personal_artists(self, username: str, user=None) -> List[str]:
+        service = self.last_fm_user_service
+        if service is None and user and getattr(user, 'lastfm_api_key', None) and getattr(user, 'lastfm_api_secret', None):
+            service = LastFmUserService(user.lastfm_api_key, user.lastfm_api_secret)
+        if not service:
             return []
-        recommendations = self.last_fm_user_service.get_recommended_artists(username, limit=50)
+        recommendations = service.get_recommended_artists(username, limit=50)
         if not recommendations:
-            recommendations = self.last_fm_user_service.get_top_artists(username, limit=50)
+            recommendations = service.get_top_artists(username, limit=50)
         return [artist.name for artist in recommendations if getattr(artist, "name", None)]
 
     def _fetch_listenbrainz_personal_artists(self, username: str) -> List[str]:
@@ -743,21 +854,23 @@ class DataHandler:
         names = playlist_artists.artists if playlist_artists else []
         return [name for name in names if name]
 
-    def _personal_source_definitions(self) -> Dict[str, Dict[str, Any]]:
+    def _personal_source_definitions(self, user=None) -> Dict[str, Dict[str, Any]]:
         """Return source-specific metadata and loaders for personal recommendations."""
+        user_has_lastfm = bool(user and getattr(user, 'lastfm_api_key', None) and getattr(user, 'lastfm_api_secret', None))
+        lastfm_service_ready = bool(self.last_fm_user_service) or user_has_lastfm
         return {
             "lastfm": {
                 "label": "Last.fm",
                 "title": "Last.fm discovery",
                 "username_attr": "lastfm_username",
-                "service_ready": bool(self.last_fm_user_service),
+                "service_ready": lastfm_service_ready,
                 "service_missing_reason": (
                     "Administrator must configure a Last.fm API key and secret in Settings before this feature can be used."
                 ),
                 "missing_username_reason": (
                     "Add your Last.fm username under Profile → Listening services to use this feature."
                 ),
-                "fetch": self._fetch_lastfm_personal_artists,
+                "fetch": lambda username: self._fetch_lastfm_personal_artists(username, user),
                 "error_message": "We couldn't reach Last.fm right now. Please try again shortly.",
             },
             "listenbrainz": {
@@ -854,8 +967,9 @@ class DataHandler:
     def personal_recommendations(self, sid: str, source: str) -> None:
         session = self.ensure_session(sid)
         source_key = (source or "").strip().lower() or "lastfm"
+        user = self._resolve_user(session.user_id)
 
-        config = self._personal_source_definitions().get(source_key)
+        config = self._personal_source_definitions(user=user).get(source_key)
         if not config:
             self._emit_personal_error(
                 sid,
@@ -865,7 +979,6 @@ class DataHandler:
             )
             return
 
-        user = self._resolve_user(session.user_id)
         if not user:
             self._emit_personal_error(
                 sid,
@@ -1484,12 +1597,14 @@ class DataHandler:
     # Preview ---------------------------------------------------------
     def preview(self, sid: str, raw_artist_name: str) -> None:
         artist_name = urllib.parse.unquote(raw_artist_name)
+        session = self.ensure_session(sid)
+        user = self._resolve_user(session.user_id)
         try:
             preview_info: dict | str
             biography = None
             lfm = pylast.LastFMNetwork(
-                api_key=self.last_fm_api_key,
-                api_secret=self.last_fm_api_secret,
+                api_key=self.get_lastfm_api_key(user),
+                api_secret=self.get_lastfm_api_secret(user),
             )
             search_results = lfm.search_for_artist(artist_name)
             artists = search_results.get_next_page()
@@ -1520,11 +1635,11 @@ class DataHandler:
 
         self.socketio.emit("lastfm_preview", preview_info, room=sid)
 
-    def _fetch_lastfm_top_tracks(self, artist_name: str) -> List[Any]:
+    def _fetch_lastfm_top_tracks(self, artist_name: str, user=None) -> List[Any]:
         """Fetch top Last.fm tracks for an artist, returning an empty list on network errors."""
         lfm = pylast.LastFMNetwork(
-            api_key=self.last_fm_api_key,
-            api_secret=self.last_fm_api_secret,
+            api_key=self.get_lastfm_api_key(user),
+            api_secret=self.get_lastfm_api_secret(user),
         )
         try:
             artist = lfm.get_artist(artist_name)
@@ -1624,8 +1739,10 @@ class DataHandler:
 
     def prehear(self, sid: str, raw_artist_name: str) -> None:
         artist_name = urllib.parse.unquote(raw_artist_name)
-        yt_key = (self.youtube_api_key or "").strip()
-        top_tracks = self._fetch_lastfm_top_tracks(artist_name)
+        session = self.ensure_session(sid)
+        user = self._resolve_user(session.user_id)
+        yt_key = (self.get_youtube_api_key(user) or "").strip()
+        top_tracks = self._fetch_lastfm_top_tracks(artist_name, user)
         try:
             result = self._resolve_audio_preview(artist_name, top_tracks, yt_key)
         except Exception as exc:  # pragma: no cover - network errors

--- a/src/sonobarr_app/web/main.py
+++ b/src/sonobarr_app/web/main.py
@@ -26,6 +26,32 @@ def _update_user_profile(form_data, user):
     user.lastfm_username = lastfm_username or None
     user.listenbrainz_username = listenbrainz_username or None
 
+    # Per-user API keys (optional overrides for global keys)
+    lastfm_api_key = (form_data.get("lastfm_api_key") or "").strip()
+    lastfm_api_secret = (form_data.get("lastfm_api_secret") or "").strip()
+    youtube_api_key = (form_data.get("youtube_api_key") or "").strip()
+    openai_api_key = (form_data.get("openai_api_key") or "").strip()
+    openai_api_base = (form_data.get("openai_api_base") or "").strip()
+    openai_model = (form_data.get("openai_model") or "").strip()
+    openai_extra_headers = (form_data.get("openai_extra_headers") or "").strip()
+    openai_max_seed_artists_raw = (form_data.get("openai_max_seed_artists") or "").strip()
+
+    user.lastfm_api_key = lastfm_api_key or None
+    user.lastfm_api_secret = lastfm_api_secret or None
+    user.youtube_api_key = youtube_api_key or None
+    user.openai_api_key = openai_api_key or None
+    user.openai_api_base = openai_api_base or None
+    user.openai_model = openai_model or None
+    user.openai_extra_headers = openai_extra_headers or None
+
+    if openai_max_seed_artists_raw:
+        try:
+            user.openai_max_seed_artists = int(openai_max_seed_artists_raw)
+        except ValueError:
+            user.openai_max_seed_artists = None
+    else:
+        user.openai_max_seed_artists = None
+
     new_password = form_data.get("new_password", "")
     confirm_password = form_data.get("confirm_password", "")
     current_password = form_data.get("current_password", "")

--- a/src/templates/profile.html
+++ b/src/templates/profile.html
@@ -45,6 +45,54 @@
             </div>
             {% if not current_user.oidc_id %}
             <hr>
+            <p class="fw-semibold">External API Keys (optional)</p>
+            <p class="text-muted small">Override global API keys with your own. Leave blank to use the admin's global keys.</p>
+
+            <div class="mb-3">
+              <label for="lastfm_api_key" class="form-label">Last.fm API Key</label>
+              <input type="text" class="form-control" id="lastfm_api_key" name="lastfm_api_key"
+                     value="{{ current_user.lastfm_api_key or '' }}" placeholder="Your Last.fm API Key (optional)">
+            </div>
+            <div class="mb-3">
+              <label for="lastfm_api_secret" class="form-label">Last.fm API Secret</label>
+              <input type="text" class="form-control" id="lastfm_api_secret" name="lastfm_api_secret"
+                     value="{{ current_user.lastfm_api_secret or '' }}" placeholder="Your Last.fm API Secret (optional)">
+            </div>
+
+            <div class="mb-3">
+              <label for="youtube_api_key" class="form-label">YouTube API Key</label>
+              <input type="text" class="form-control" id="youtube_api_key" name="youtube_api_key"
+                     value="{{ current_user.youtube_api_key or '' }}" placeholder="Your YouTube API Key (optional)">
+              <div class="form-text">Powers the YouTube preview player. Falls back to iTunes samples if not set.</div>
+            </div>
+
+            <div class="mb-3">
+              <label for="openai_api_key" class="form-label">LLM API Key</label>
+              <input type="text" class="form-control" id="openai_api_key" name="openai_api_key"
+                     value="{{ current_user.openai_api_key or '' }}" placeholder="sk-... (optional)">
+              <div class="form-text">For OpenAI, Azure, or compatible providers. Leave blank to use admin's global key.</div>
+            </div>
+            <div class="mb-3">
+              <label for="openai_api_base" class="form-label">LLM API Base URL</label>
+              <input type="url" class="form-control" id="openai_api_base" name="openai_api_base"
+                     value="{{ current_user.openai_api_base or '' }}" placeholder="https://api.openai.com/v1 (optional)">
+            </div>
+            <div class="mb-3">
+              <label for="openai_model" class="form-label">LLM Model Name</label>
+              <input type="text" class="form-control" id="openai_model" name="openai_model"
+                     value="{{ current_user.openai_model or '' }}" placeholder="gpt-4o-mini (optional)">
+            </div>
+            <div class="mb-3">
+              <label for="openai_max_seed_artists" class="form-label">LLM Max Seed Artists</label>
+              <input type="number" class="form-control" id="openai_max_seed_artists" name="openai_max_seed_artists"
+                     value="{{ current_user.openai_max_seed_artists or '' }}" min="1" step="1" placeholder="5 (optional)">
+            </div>
+            <div class="mb-3">
+              <label for="openai_extra_headers" class="form-label">LLM Extra Headers (JSON)</label>
+              <textarea class="form-control" id="openai_extra_headers" name="openai_extra_headers" rows="2" placeholder='{"Authorization": "Bearer ..."} (optional)'
+              >{{ current_user.openai_extra_headers or '' }}</textarea>
+            </div>
+            <hr>
             <p class="fw-semibold">Change password</p>
             <div class="mb-3">
               <label for="current_password" class="form-label">Current password</label>

--- a/src/templates/profile.html
+++ b/src/templates/profile.html
@@ -47,6 +47,13 @@
             <hr>
             <p class="fw-semibold">External API Keys (optional)</p>
             <p class="text-muted small">Override global API keys with your own. Leave blank to use the admin's global keys.</p>
+            <!-- TODO: Encrypt stored API keys using the user's password for proper at-rest security.
+                 On password reset, require users to re-enter their keys rather than re-encrypting,
+                 so a server admin cannot extract keys by resetting passwords. -->
+            <div class="alert alert-warning py-2 px-3 small">
+              <strong>Heads up:</strong> Your API keys will be stored on this server in order to use them.
+              If you do not trust the server owner or host, do not enter your keys here.
+            </div>
 
             <div class="mb-3">
               <label for="lastfm_api_key" class="form-label">Last.fm API Key</label>
@@ -71,6 +78,10 @@
               <input type="text" class="form-control" id="openai_api_key" name="openai_api_key"
                      value="{{ current_user.openai_api_key or '' }}" placeholder="sk-... (optional)">
               <div class="form-text">For OpenAI, Azure, or compatible providers. Leave blank to use admin's global key.</div>
+            </div>
+            <div class="alert alert-info py-2 px-3 small">
+              <strong>Note:</strong> If you provide your own LLM API key, make sure to also set the correct Base URL below.
+              Local/private URLs will only work if the app is hosted on the same network.
             </div>
             <div class="mb-3">
               <label for="openai_api_base" class="form-label">LLM API Base URL</label>


### PR DESCRIPTION
Users can now configure their own Last.fm, YouTube, and LLM API keys in their Profile page. When set, user keys override the global keys for that user's sessions. If not set, falls back to admin-configured global keys automatically.

- Add API key columns to User model
- Add migration for new columns
- Add getter methods to DataHandler with user->global fallback
- Update preview/prehear/ai_prompt to use per-user keys
- Add API key form fields to profile page
- Handle API key form submission in profile update